### PR TITLE
No references to xwb1989 packages

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/xwb1989/sqlparser/dependency/sqltypes"
+	"github.com/honeycombio/sqlparser/dependency/sqltypes"
 )
 
 // GetTableName returns the table name from the SimpleTableExpr

--- a/ast.go
+++ b/ast.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/xwb1989/sqlparser/dependency/sqltypes"
+	"github.com/honeycombio/sqlparser/dependency/sqltypes"
 )
 
 // Instructions for creating new types: If a type

--- a/dependency/bson/bson_test.go
+++ b/dependency/bson/bson_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xwb1989/sqlparser/dependency/bytes2"
+	"github.com/honeycombio/sqlparser/dependency/bytes2"
 )
 
 type alltypes struct {

--- a/dependency/bson/custom_test.go
+++ b/dependency/bson/custom_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xwb1989/sqlparser/dependency/bytes2"
+	"github.com/honeycombio/sqlparser/dependency/bytes2"
 )
 
 const (

--- a/dependency/bson/marshal.go
+++ b/dependency/bson/marshal.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/xwb1989/sqlparser/dependency/bytes2"
+	"github.com/honeycombio/sqlparser/dependency/bytes2"
 )
 
 // LenWriter records the current write position on the buffer

--- a/dependency/bson/marshal_test.go
+++ b/dependency/bson/marshal_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xwb1989/sqlparser/dependency/bytes2"
+	"github.com/honeycombio/sqlparser/dependency/bytes2"
 )
 
 type String1 string

--- a/dependency/bson/marshal_util.go
+++ b/dependency/bson/marshal_util.go
@@ -9,7 +9,7 @@ package bson
 import (
 	"time"
 
-	"github.com/xwb1989/sqlparser/dependency/bytes2"
+	"github.com/honeycombio/sqlparser/dependency/bytes2"
 )
 
 // EncodeInterface bson encodes an interface{}. Elements

--- a/dependency/bson/unmarshal_util.go
+++ b/dependency/bson/unmarshal_util.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/xwb1989/sqlparser/dependency/hack"
+	"github.com/honeycombio/sqlparser/dependency/hack"
 )
 
 // VerifyObject verifies kind to make sure it's

--- a/dependency/bytes2/chunked_writer.go
+++ b/dependency/bytes2/chunked_writer.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"unicode/utf8"
 
-	"github.com/xwb1989/sqlparser/dependency/hack"
+	"github.com/honeycombio/sqlparser/dependency/hack"
 )
 
 // ChunkedWriter has the same interface as bytes.Buffer's write functions.

--- a/dependency/sqltypes/sqltypes.go
+++ b/dependency/sqltypes/sqltypes.go
@@ -14,9 +14,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/xwb1989/sqlparser/dependency/bson"
-	"github.com/xwb1989/sqlparser/dependency/bytes2"
-	"github.com/xwb1989/sqlparser/dependency/hack"
+	"github.com/honeycombio/sqlparser/dependency/bson"
+	"github.com/honeycombio/sqlparser/dependency/bytes2"
+	"github.com/honeycombio/sqlparser/dependency/hack"
 )
 
 var (

--- a/parsed_query.go
+++ b/parsed_query.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/xwb1989/sqlparser/dependency/sqltypes"
+	"github.com/honeycombio/sqlparser/dependency/sqltypes"
 )
 
 type bindLocation struct {

--- a/parsed_query_test.go
+++ b/parsed_query_test.go
@@ -7,7 +7,7 @@ package sqlparser
 import (
 	"testing"
 
-	"github.com/xwb1989/sqlparser/dependency/sqltypes"
+	"github.com/honeycombio/sqlparser/dependency/sqltypes"
 )
 
 func TestParsedQuery(t *testing.T) {


### PR DESCRIPTION
I couldn't build this package because the source we forked from has had a significant refactor. We forked the references to the dependencies to this project so if we just use them in the import is will build just fine.